### PR TITLE
Enable Auto-Formatting

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,6 +15,17 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Get Changed Files
+        id: changes
+        run: |
+          echo "changed-files=$(git diff --name-only ${{ github.event.pull_request.head.sha }} ${{ github.sha }} | xargs)" >> "$GITHUB_OUTPUT"
+      - name: Check Formatting
+        uses: JohnnyMorganz/stylua-action@v2
+        if: ${{ steps.changes.outputs.changed-files }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: v0.16.1
+          args: --check --allow-hidden ${{ steps.changes.outputs.changed-files }}
       - name: Lint Code Base
         uses: github/super-linter/slim@v4
         env:

--- a/.pre-commit-config.yml
+++ b/.pre-commit-config.yml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/JohnnyMorganz/StyLua
+    rev: v0.16.1
+    hooks:
+      - id: stylua-system

--- a/.pre-commit-config.yml
+++ b/.pre-commit-config.yml
@@ -1,4 +1,16 @@
 repos:
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.29.0
+    hooks:
+      - id: yamllint
+  - repo: https://github.com/Calinou/pre-commit-luacheck
+    rev: v1.0.0
+    hooks:
+      - id: luacheck
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.33.0
+    hooks:
+      - id: markdownlint
   - repo: https://github.com/JohnnyMorganz/StyLua
     rev: v0.16.1
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,15 +30,16 @@ Please follow this simple checklist for every blueprint README file:
 - Device pictures and vendor logos are always welcome, but we ask you to respect the author of said pictures and to follow copyright and licencing guidelines.
 - References should be given to the device vendor page, manual, API documentation, etc.
 
-## Linters
+## Linters and Formatters
 
 Blueprint files are validated using several linters:
 
 - [`yamllint`](https://yamllint.readthedocs.io/en/stable/)
 - [`luacheck`](https://luacheck.readthedocs.io/en/stable/)
 - [`markdownlint`](https://github.com/igorshubovych/markdownlint-cli#readme)
+- [`StyLua`](https://github.com/JohnnyMorganz/StyLua)
 
-The configuration can be found in `.yamllint.yml`, `.luacheckrc` and `.markdownlint.yml` files respectively.
+The configuration can be found in `.yamllint.yml`, `.luacheckrc`, `.markdownlint.yml` and `stylua.toml` files respectively.
 
 Run the linters locally before creating a pull request:
 
@@ -46,20 +47,28 @@ Run the linters locally before creating a pull request:
 luacheck .
 yamllint .
 markdownlint .
+stylua --check .
+```
+
+:warning: Some of the existing files have not been auto-formatted yet, so `stylua --check .` will fail. Changes introduced by auto-formatting require [review, which is still in progress](https://github.com/Enapter/marketplace/issues/199).
+
+To automatically run the checks before each commit, consider enabling [pre-commit hooks](https://pre-commit.com):
+
+```bash
+pre-commit install --config .pre-commit-config.yml
 ```
 
 ## Lua Codestyle
 
+Lua code is expected to be autoformatted with [`StyLua`](https://github.com/JohnnyMorganz/StyLua).
+
+Here are some conventions besides that enforced by the auto-formatter:
+
 - Document with [LDoc](https://stevedonovan.github.io/ldoc/).
-- Use 2 spaces for indentation.
 - Use `snake_case` for variables and functions.
 - Use `CamelCase` for OOP class names.
 - Use `UPPER_CASE` for constants. Put top-level constants at the beginning of the file.
 - Use `is_` when naming boolean functions, e.g. `is_between()`.
-- Use single quotes `'` over double `"` quotes. Use double quotes when string contains single quotes already.
-- Use parenthesis in function calls (`local a = myfun('any')`). Though it's ok to omit it for `require` (`local a = require 'rules'`).
-- No spaces in concatenation operator (`'some'..var..' ok'`).
-- No spaces around function args declaration (`function hello(a, b)`).
 - Typecheck in critical places (`assert(type(myvar) == 'string')`).
 
 Some more coding conventions are available in the [LuaRocks style guide](https://github.com/luarocks/lua-style-guide).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Blueprint files are validated using several linters:
 - [`luacheck`](https://luacheck.readthedocs.io/en/stable/)
 - [`markdownlint`](https://github.com/igorshubovych/markdownlint-cli#readme)
 
-The configuration can be found in `.yamllint.yml`, `.luacheckrc` and `..markdownlint.yml` files respectively.
+The configuration can be found in `.yamllint.yml`, `.luacheckrc` and `.markdownlint.yml` files respectively.
 
 Run the linters locally before creating a pull request:
 

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,7 @@
+column_width = 100
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 2
+quote_style = "AutoPreferSingle"
+call_parentheses = "Always"
+collapse_simple_statement = "Never"


### PR DESCRIPTION
Formatting conventions are effortlessly enforced using auto-formatting. It saves waste amounts of time and mental energy of both developers and reviewers.

This MR enables auto-formatting of Lua code using [StyLua](https://github.com/JohnnyMorganz/StyLua). The project seems to be actively maintained.

See also:

- https://github.com/Enapter/marketplace/pull/195#discussion_r1118420872