### PR TITLE
bug: use public communication_module manifest section

### DIFF
--- a/battery_management_systems/lg_resu_prime_http/manifest.yml
+++ b/battery_management_systems/lg_resu_prime_http/manifest.yml
@@ -9,10 +9,9 @@ support:
 license: MIT
 verification_level: verified
 
-communication_modules:
-  eth:
-    product: ENP-VIRTUAL
-    lua_file: firmware.lua
+communication_module:
+  product: ENP-VIRTUAL
+  lua_file: firmware.lua
 
 properties:
   model:

--- a/flow_meters/bronkhorst_f111b/manifest.yml
+++ b/flow_meters/bronkhorst_f111b/manifest.yml
@@ -10,10 +10,9 @@ support:
   email: support@enapter.com
 verification_level: verified
 
-communication_modules:
-  rs485:
-    product: ENP-RS485
-    lua_file: firmware.lua
+communication_module:
+  product: ENP-RS485
+  lua_file: firmware.lua
 
 properties:
   vendor:


### PR DESCRIPTION
We should not use `communication_modules`. Because it is not documented and only for internal usage.