### PR TITLE
bug(intelligent_energy_fcm_80x): fix telemetry

### DIFF
--- a/fuel_cells/intelligent_energy_fcm_801/manifest.yml
+++ b/fuel_cells/intelligent_energy_fcm_801/manifest.yml
@@ -85,7 +85,7 @@ telemetry:
     display_name: Fan SP duty
   run_hours:
     type: float
-    unit: h
+    unit: s
     display_name: Run Hours
   total_run_energy:
     type: float

--- a/fuel_cells/intelligent_energy_fcm_804/firmware.lua
+++ b/fuel_cells/intelligent_energy_fcm_804/firmware.lua
@@ -267,7 +267,7 @@ function flag_a_error(flag)
   if flag & 0x00000040 ~= 0 then
     table.insert(errors, 'Sib2Fault')
   end
-  if flag & 0x00000040 ~= 0 then
+  if flag & 0x00000020 ~= 0 then
     table.insert(errors, 'Sib3Fault')
   end
   if flag & 0x00000010 ~= 0 then

--- a/fuel_cells/intelligent_energy_fcm_804/manifest.yml
+++ b/fuel_cells/intelligent_energy_fcm_804/manifest.yml
@@ -86,7 +86,7 @@ telemetry:
     display_name: Fan SP duty
   run_hours:
     type: float
-    unit: h
+    unit: s
     display_name: Run Hours
   total_run_energy:
     type: float


### PR DESCRIPTION
There a two bugs:
- duplicated fault flag in fcm_804;
- incorrect units for run_hours.

Run hours are showed on dashboards as 300+ years. It can be fixed by divide telemetry value to keep the unit as `h`, but that breaks history.